### PR TITLE
Added RHEL support

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,14 @@
+chrony_package_info:
+  pkg_mgr: yum
+  args:
+      name: "{{ item }}"
+      state: latest
+  pre_pkgs: []
+  pkgs:
+    - chrony
+
+chrony_path_info:
+  conf_path: /etc/chrony.conf
+
+chrony_service_info:
+  name: chronyd


### PR DESCRIPTION
RHEL7 does not require the pre_pkgs which are defined for centos.