### PR TITLE
Adapt to chrony-2.2 or newer version

### DIFF
--- a/templates/chrony.conf
+++ b/templates/chrony.conf
@@ -3,10 +3,6 @@ server {{ server }} {{ chrony_server_settings }}
 {% endfor -%}
 
 keyfile {{ chrony_keyfile_path }}
-commandkey 1
-{% if chrony_generate_command_key is defined -%}
-{{ chrony_generate_command_key }}
-{% endif -%}
 
 driftfile {{ chrony_driftfile_path }}
 log tracking measurements statistics

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -24,4 +24,3 @@ chrony_bind_addresses:
 chrony_stratum_weight: stratumweight 0
 
 chrony_server_settings: iburst
-chrony_generate_command_key: generatecommandkey


### PR DESCRIPTION
Chrony 2.2 has dropped support for command key authentication
(https://chrony.tuxfamily.org/news.html) therefore it warns,
when it is set